### PR TITLE
Added numpy to the default installation for python3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ Alternatively, you can follow the steps below.
  
 You may consider to put this in a cronjob for your user `strands` to update every night after a successful jenkins build. This will make sure that you always have the latest installation.
 
+### adding a library to your python3.3 installation, e.g. numpy:
+
+ 1. cd ${workspace}/tmp && git clone https://github.com/numpy/numpy.git
+ 1. cd numpy && git checkout v1.7.1
+ 1. ${workspace}/bin/python3.3 setup.py install
+
+where `${workspace}` is, e.g., `/opt/strands`.
+
 ### updating MORSE
 As user `strands` run:
 

--- a/setup.sh
+++ b/setup.sh
@@ -102,6 +102,11 @@ ${workspace}/bin/python3.3 setup.py install
 cd ${workspace}/tmp && git clone https://github.com/ros/catkin.git
 cd catkin && git checkout 0.5.65
 ${workspace}/bin/python3.3 setup.py install
+cd ${workspace}/tmp && git clone https://github.com/numpy/numpy.git
+cd numpy && git checkout v1.7.1
+${workspace}/bin/python3.3 setup.py install
+
+
 
 echo "Install MORSE (latest from git master branch)"
 (cd ${workspace}/src && git clone https://github.com/strands-project/morse.git && \


### PR DESCRIPTION
This is only needed for the automatic scene generation in MORSE. You can add it manually as described in the README.
