### PR TITLE
New linda launch files

### DIFF
--- a/strands_linda/launch/cameras.launch
+++ b/strands_linda/launch/cameras.launch
@@ -1,0 +1,15 @@
+<launch>
+    <arg name="with_camera" default="true" />
+    <arg name="with_chest_camera" default="true" />
+    <arg name="inverted" default="no" />.
+
+    <include file="$(find openni_wrapper)/launch/main.launch">
+         <arg name="camera" value="head_xtion" />
+         <arg name="publish_tf" value="false" />
+         <arg name="camera2" value="chest_xtion" />
+         <arg name="with_camera" value="$(arg with_camera)" />
+         <arg name="with_camera2" value="$(arg with_chest_camera)" />
+         <arg name="inverted" value="$(arg inverted)" />
+    </include>
+
+</launch>

--- a/strands_linda/launch/linda-base.launch
+++ b/strands_linda/launch/linda-base.launch
@@ -1,7 +1,12 @@
 <launch>
-	<include file="$(find scitos_bringup)/launch/scitos.launch" />
-	<include file="$(find strands_webtools)/webtools.launch" />
-	<include file="$(find scitos_cmd_vel_mux)/launch/mux.launch" />
-	<include file="$(find scitos_teleop)/launch/teleop_joystick_mux.launch" />
-	<include file="$(find ros_mary_tts)/launch/ros_mary.launch" />    
+    <!-- SCITOS no camera -->
+        <include file="$(find scitos_bringup)/launch/no_camera.launch"/>     
+
+    <!-- Additional nodes -->
+        <include file="$(find strands_datacentre)/launch/datacentre.launch"/>     
+        <include file="$(find scitos_cmd_vel_mux)/launch/mux.launch" />
+        <include file="$(find scitos_teleop)/launch/teleop_joystick_mux.launch" />
+        <node name="odometry_mileage" pkg="odometry_mileage" type="odometry_mileage"/>
+        <node name="set_mondev" pkg="linda_utils" type="set_mondev.sh" />
+
 </launch>

--- a/strands_linda/launch/linda-bringup.launch
+++ b/strands_linda/launch/linda-bringup.launch
@@ -13,7 +13,7 @@
     <!-- Additional nodes -->
         <include file="$(find scitos_docking)/launch/charging_mux.launch"/>
         <include file="$(find scitos_ptu_sweep)/launch/ptu_sweep.launch"/>
-        <include file="$(find scitos_ramp)/launch/rampclimbing_mux.launch"/>
+        <include file="$(find scitos_ramp_climb)/launch/rampclimbing_mux.launch"/>
 
 
 </launch>

--- a/strands_linda/launch/linda-bringup.launch
+++ b/strands_linda/launch/linda-bringup.launch
@@ -14,6 +14,6 @@
         <include file="$(find scitos_docking)/launch/charging_mux.launch"/>
         <include file="$(find scitos_ptu_sweep)/launch/ptu_sweep.launch"/>
         <include file="$(find scitos_ramp_climb)/launch/rampclimbing_mux.launch"/>
-
+        <include file="$(find strands_webtools)/launch/webtools_robot.launch"/> 
 
 </launch>

--- a/strands_linda/launch/linda-bringup.launch
+++ b/strands_linda/launch/linda-bringup.launch
@@ -1,0 +1,18 @@
+<launch>
+    <arg name="with_camera" default="true" />
+    <arg name="with_chest_camera" default="true" />
+    <arg name="inverted" default="no" />
+
+    <include file="$(find strands_linda)/launch/linda-base.launch"/>
+    <include file="$(find strands_linda)/launch/cameras.launch">
+        <arg name="with_camera" default="true" />
+        <arg name="with_chest_camera" default="true" />
+        <arg name="inverted" default="no" />
+    </include>
+
+    <!-- Additional nodes -->
+        <include file="$(find scitos_docking)/launch/charging_mux.launch"/>
+        <include file="$(find scitos_ptu_sweep)/launch/ptu_sweep.launch"/>
+
+
+</launch>

--- a/strands_linda/launch/linda-bringup.launch
+++ b/strands_linda/launch/linda-bringup.launch
@@ -13,6 +13,7 @@
     <!-- Additional nodes -->
         <include file="$(find scitos_docking)/launch/charging_mux.launch"/>
         <include file="$(find scitos_ptu_sweep)/launch/ptu_sweep.launch"/>
+        <include file="$(find scitos_ramp)/launch/rampclimbing_mux.launch"/>
 
 
 </launch>


### PR DESCRIPTION
The old linda-base.launch stopped working quite a while ago.
These new files now do the following:
- linda-base: launches scitos_bringup/nocameras.launch + datacentre, cmd_vel_mux, joystick (muxed), odometry_mileage, and mon_dev
- cameras: the new openni wrapper. Args: with_camera (true), with_chest_camera (true), invert (no)
- linda-bringup.launch: linda-base, cameras, charging (muxed), ptu_sweep, ramp_climb, webtools. Args: same as cameras
