### PR TITLE
Using old openni and included mary into linda launch files

### DIFF
--- a/strands_linda/launch/cameras.launch
+++ b/strands_linda/launch/cameras.launch
@@ -3,13 +3,18 @@
     <arg name="with_chest_camera" default="true" />
     <arg name="inverted" default="no" />.
 
-    <include file="$(find openni_wrapper)/launch/main.launch">
+<!--    <include file="$(find openni_wrapper)/launch/main.launch">
          <arg name="camera" value="head_xtion" />
          <arg name="publish_tf" value="false" />
          <arg name="camera2" value="chest_xtion" />
          <arg name="with_camera" value="$(arg with_camera)" />
          <arg name="with_camera2" value="$(arg with_chest_camera)" />
          <arg name="inverted" value="$(arg inverted)" />
+    </include> -->
+
+    <include file="$(find openni_launch)/launch/openni.launch">
+         <arg name="camera" value="head_xtion" />
+         <arg name="publish_tf" value="false" />
     </include>
 
 </launch>

--- a/strands_linda/launch/linda-bringup.launch
+++ b/strands_linda/launch/linda-bringup.launch
@@ -14,6 +14,7 @@
         <include file="$(find scitos_docking)/launch/charging_mux.launch"/>
         <include file="$(find scitos_ptu_sweep)/launch/ptu_sweep.launch"/>
         <include file="$(find scitos_ramp_climb)/launch/rampclimbing_mux.launch"/>
-        <include file="$(find strands_webtools)/launch/webtools_robot.launch"/> 
+        <include file="$(find strands_webtools)/launch/webtools_robot.launch"/>
+        <include file="$(find ros_mary_tts)/launch/ros_mary.launch" /> 
 
 </launch>


### PR DESCRIPTION
The new openni wrapper did not work [reliable enough](https://github.com/strands-project/scitos_robot/issues/29) and [not as expected](https://github.com/strands-project/scitos_robot/issues/34).

When creating the files I simply forgot mary. This has been added now. 
