### PR TITLE
Moving strands_systems to strands-extras.yaml file.

### DIFF
--- a/strands_rosinstall/strands-base.yaml
+++ b/strands_rosinstall/strands-base.yaml
@@ -49,9 +49,3 @@
    uri: 'https://github.com/strands-project/ros_datacentre.git'
    version: hydro-devel
 
-# Systems
-- git: 
-   local-name: strands_systems
-   uri: 'https://github.com/strands-project/strands_systems.git'
-   version: hydro-devel
-

--- a/strands_rosinstall/strands-extras.yaml
+++ b/strands_rosinstall/strands-extras.yaml
@@ -54,3 +54,9 @@
     local-name: activity_analysis
     uri: https://github.com/strands-project/activity_analysis.git
     version: hydro-devel
+
+# Systems
+- git: 
+   local-name: strands_systems
+   uri: 'https://github.com/strands-project/strands_systems.git'
+   version: hydro-devel


### PR DESCRIPTION
This fixes build issues by removing all the repositories (i.e. strands_systems) from strands-base.yaml that have dependencies in other install files.
