### PR TITLE
Changed ros_datacentre in strands-base.yaml to mongodb_store

### DIFF
--- a/strands_rosinstall/strands-base.yaml
+++ b/strands_rosinstall/strands-base.yaml
@@ -45,8 +45,8 @@
     version: hydro-devel
 
 - git: 
-   local-name: ros_datacentre
-   uri: 'https://github.com/strands-project/ros_datacentre.git'
+   local-name: mongodb_store
+   uri: 'https://github.com/strands-project/mongodb_store.git'
    version: hydro-devel
 
 # Openni driver


### PR DESCRIPTION
for the next system update please do the following:
`cd /opt/strands/strands_catkin_ws/src`
`wstool rm ros_datacentre`
`rm -rf ros_datacentre`
`wstool merge https://raw.githubusercontent.com/strands-project/strands_systems/hydro-devel/strands_rosinstall/strands-base.yaml`
`wstool update`
