### PR TITLE
Changing twitter_bootstrap branch to master

### DIFF
--- a/strands_rosinstall/strands-extras.yaml
+++ b/strands_rosinstall/strands-extras.yaml
@@ -28,7 +28,7 @@
 - git: 
    local-name: twitter_bootstrap
    uri: 'https://github.com/strands-project/twitter_bootstrap.git'
-   version: hydro-devel
+   version: master
 
 - git:
     local-name: strands_hri


### PR DESCRIPTION
The new twitter_boostrap repo does not have a hydro-devel branch.
