### PR TITLE
Change scitos_2d_navigation launch includes to strands_movebase

### DIFF
--- a/strands_bob/launch/bob-bringup.launch
+++ b/strands_bob/launch/bob-bringup.launch
@@ -17,7 +17,7 @@
         <arg name="js" value="$(arg js)" />
     </include>
     <include file="$(find scitos_docking)/launch/charging.launch"/>
-    <include file="$(find scitos_2d_navigation)/launch/scitos_2d_nav.launch">
+    <include file="$(find strands_movebase)/launch/movebase.launch">
          <arg name="with_camera" value="$(arg with_nav_camera)" /> 
 	 <arg name="camera" value="$(arg camera)" /> 
          <arg name="map"  value="$(arg map)" />    

--- a/strands_bob/package.xml
+++ b/strands_bob/package.xml
@@ -40,6 +40,7 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+  <run_depend>strands_movebase</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/strands_linda/launch/linda-new-bringup.launch
+++ b/strands_linda/launch/linda-new-bringup.launch
@@ -11,7 +11,7 @@
         <arg name="js" value="$(arg js)" />
     </include>
     <include file="$(find scitos_docking)/launch/charging.launch"/>
-    <include file="$(find scitos_2d_navigation)/launch/scitos_2d_nav.launch">
+    <include file="$(find strands_movebase)/launch/movebase.launch">
          <arg name="with_camera" value="$(arg with_nav_camera)" /> 
 	 <arg name="camera" value="$(arg camera)" /> 
          <arg name="map"  value="$(arg map)" />    

--- a/strands_linda/launch/linda_navigation_nhm.launch
+++ b/strands_linda/launch/linda_navigation_nhm.launch
@@ -15,7 +15,7 @@
     <machine name="$(arg machine)" address="$(arg machine)" env-loader="/opt/strands/strands_catkin_ws/devel/env.sh" user="$(arg user)" default="true"/>
 
     <!-- launch 2d Navigation -->
-    <include file="$(find scitos_2d_navigation)/launch/scitos_2d_nav.launch">
+    <include file="$(find strands_movebase)/launch/movebase.launch">
         <arg name="machine"  value="$(arg machine)"/>
         <arg name="user"  value="$(arg user)"/>
         <arg name="with_camera" value="$(arg with_camera)"/>

--- a/strands_linda/package.xml
+++ b/strands_linda/package.xml
@@ -46,6 +46,7 @@
   <run_depend>ros_mary_tts</run_depend>
   <run_depend>scitos_teleop</run_depend>
   <run_depend>strands_webtools</run_depend>
+  <run_depend>strands_movebase</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/strands_rosie/launch/rosie_navigation.launch
+++ b/strands_rosie/launch/rosie_navigation.launch
@@ -14,7 +14,7 @@
 
 
     <!-- launch 2d Navigation -->
-    <include file="$(find scitos_2d_navigation)/launch/scitos_2d_nav.launch">
+    <include file="$(find strands_movebase)/launch/movebase.launch">
         <arg name="machine" value="$(arg machine)"/>
         <arg name="user" value="$(arg user)"/>
         <arg name="with_camera" value="$(arg with_camera)"/>

--- a/strands_rosie/package.xml
+++ b/strands_rosie/package.xml
@@ -40,6 +40,7 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+  <run_depend>strands_movebase</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
Changed the systems using `scitos_2d_navigation` to `strands_movebase` except for the simulation which can only use `scitos_2d_nav` anyways. Also added `strands_movebase` as a `run_depend` in the packages using it.
