### PR TITLE
Pass-through the EBC port for docking.

### DIFF
--- a/strands_bringup/launch/strands_navigation.launch
+++ b/strands_bringup/launch/strands_navigation.launch
@@ -18,6 +18,9 @@
   <arg name="with_site_movebase_params" default="false"/>
   <arg name="site_movebase_params" default=""/>
 
+  <!-- WARNING: This EBC will be powerded on and off during docking! -->
+  <arg name="lightEBC" default=""/>
+
   <arg name="machine" default="localhost" />
   <arg name="user" default="" />
 
@@ -51,11 +54,12 @@
   <include unless="$(arg with_mux)" file="$(find scitos_docking)/launch/charging.launch">
     <arg name="machine"  value="$(arg machine)"/>
     <arg name="user"  value="$(arg user)"/>
-
+    <arg name="lightEBC"  value="$(arg lightEBC)"/>
   </include>
   <include if="$(arg with_mux)" file="$(find scitos_docking)/launch/charging_mux.launch">
     <arg name="machine"  value="$(arg machine)"/>
     <arg name="user"  value="$(arg user)"/>
+    <arg name="lightEBC"  value="$(arg lightEBC)"/>
   </include>
 
   <!-- Ramp Climbing -->


### PR DESCRIPTION
DEFAULT TO NONE, ONLY ONE ROBOT HAS A LIGHT IN THERE.
Feels good to shout once in the morning.

See strands-project/scitos_apps#120
