### PR TITLE
Make the subsampling parameters configurable.

### DIFF
--- a/strands_bringup/launch/strands_navigation.launch
+++ b/strands_bringup/launch/strands_navigation.launch
@@ -18,6 +18,10 @@
   <arg name="with_site_movebase_params" default="false"/>
   <arg name="site_movebase_params" default=""/>
 
+  <arg name="subsample_resolution" default="0.05"/>
+  <arg name="subsample_min_points" default="5"/>
+  <arg name="subsample_skip_points" default="20"/>
+
   <!-- WARNING: This EBC will be powerded on and off during docking! -->
   <arg name="lightEBC" default=""/>
 
@@ -48,6 +52,10 @@
 
     <arg name="with_site_movebase_params" value="$(arg with_site_movebase_params)"/>
     <arg name="site_movebase_params" value="$(arg site_movebase_params)"/>
+
+    <arg name="subsample_resolution" value="$(arg subsample_resolution)"/>
+    <arg name="subsample_min_points" value="$(arg subsample_min_points)"/>
+    <arg name="subsample_skip_points" value="$(arg subsample_skip_points)"/>
   </include>
 
   <!--- Docking -->


### PR DESCRIPTION
Together with @Pandoro we found out our problem of strands-project/strands_movebase#19. This PR _doesn't change defaults_, it's just so that we can change them more easily and find the right value.

strands-project/strands_movebase#23
