### PR TITLE
Include pc_monitor in robot bringup.

### DIFF
--- a/strands_bringup/launch/strands_robot.launch
+++ b/strands_bringup/launch/strands_robot.launch
@@ -35,8 +35,7 @@
 
 
 	<!-- PC Monitor -->
-	<!-- Not released -->
-	<!-- node name="pc_monitor" pkg="scitos_pc_monitor" type="pc_monitor.py" / -->
+	<node name="pc_monitor" pkg="scitos_pc_monitor" type="pc_monitor" />
 
 	<!-- Diagnostics aggregator -->
 	<include file="$(find scitos_bringup)/launch/diagnostic_agg.launch" >


### PR DESCRIPTION
Includes the now released pc_monitor in the strands_robot launch file.
