### PR TITLE
Added human_aware_navigation and dependencies to strands_navigation.launch

### DIFF
--- a/strands_bringup/launch/strands_navigation.launch
+++ b/strands_bringup/launch/strands_navigation.launch
@@ -14,6 +14,7 @@
   <arg name="z_stair_threshold" default="0.12"/>
   <arg name="z_obstacle_threshold" default="0.15"/>
   <arg name="with_head_xtion" default="false"/>
+  <arg name="with_human_aware" default="false"/>
 
   <arg name="with_site_movebase_params" default="false"/>
   <arg name="site_movebase_params" default=""/>
@@ -89,4 +90,10 @@
 
   <node name="odometry_mileage" pkg="odometry_mileage" type="odometry_mileage"/>
   <node name="door_pass_node" pkg="door_pass" type="door_pass.py" output="screen" />
+
+  <group if="$(arg with_human_aware)">
+    <node name="gaze_at_pose" pkg="strands_gazing" type="gaze_at_pose"/>
+    <node name="pose_extractor" pkg="pose_extractor" type="extract_last_pose_from_path.py"/>
+    <node name="human_aware_navigation" pkg="strands_human_aware_navigation" type="human_aware_navigation.py"/>
+  </group>
 </launch>

--- a/strands_bringup/package.xml
+++ b/strands_bringup/package.xml
@@ -24,6 +24,7 @@
     <run_depend>strands_apps</run_depend>
     <run_depend>strands_navigation</run_depend>
     <run_depend>strands_ui</run_depend>
+    <run_depend>strands_hri</run_depend>
 
     <export>
 


### PR DESCRIPTION
See #101. 
Default behaviour is unchanged. To run with human_aware_navigation, start with `with_human_aware:=true`.

I think this makes most sense and we don't need a dedicated launch file for that.
