### PR TITLE
Setting default of with_human_aware to true

### DIFF
--- a/strands_bringup/launch/strands_navigation.launch
+++ b/strands_bringup/launch/strands_navigation.launch
@@ -14,7 +14,7 @@
   <arg name="z_stair_threshold" default="0.12"/>
   <arg name="z_obstacle_threshold" default="0.15"/>
   <arg name="with_head_xtion" default="false"/>
-  <arg name="with_human_aware" default="false"/>
+  <arg name="with_human_aware" default="true"/>
 
   <arg name="with_site_movebase_params" default="false"/>
   <arg name="site_movebase_params" default=""/>


### PR DESCRIPTION
Now that https://github.com/strands-project/strands_hri/pull/91 is merged, human aware navigation dynamically subscribes and unsubscribes from the ppl perception pipeline. this means:
- If the edge uses human aware navigation, everything works as expected. While the robot is driving it subscribes to the ppl perception. If no goal is active it unsubscribes.
- If the edge uses move_base, human ware navigation is unsubscribed from the ppl perception, not causing any processing.
- If the ppl perception is not running, human aware navigation behaves like move_base + some gazing behaviour

Therefore, having it running by default does not cause additional load on the CPU if it is not used but it prevents confusion if it is used in the edge but not running.
