### PR TITLE
Add parameter to disable megnetic barrier.

### DIFF
--- a/strands_bringup/launch/strands_robot.launch
+++ b/strands_bringup/launch/strands_robot.launch
@@ -6,7 +6,7 @@
 	<arg name="js" default="$(optenv JOYSTICK_DEVICE /dev/js1)" />
 	<arg name="laser" default="/dev/ttyUSB0" />
 	<arg name="scitos_config" default="$(find scitos_mira)/resources/SCITOSDriver.xml"/>
-
+	<arg name="with_magnetic_barrier" default="true"/>
 
     <!-- NOW when launching in a remote mode it will need the ROS_ENV_LOADER set if not it will leave it empty -->
     <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="true" />
@@ -17,6 +17,7 @@
 	    <arg name="machine"  value="$(arg machine)"/>
 	    <arg name="user"  value="$(arg user)"/>
 		<arg name="SCITOS_CONFIG" value="$(arg scitos_config)"/>
+		<arg name="BARRIER_ENABLED" value="$(arg with_magnetic_barrier)"/>
 	</include>
 
 	<!-- SICK S300 -->


### PR DESCRIPTION
This allows to start strands_robot with the magnetic barried disabled:

```
roslaunch strands_bringup strands_robot.launch with_magnetic_barrier:=false
```

depends on https://github.com/strands-project/scitos_drivers/pull/106.
