### PR TITLE
Edited strands_navigation.launch to include "with_social_layer" to surport social navigation layers

### DIFF
--- a/strands_bringup/launch/strands_navigation.launch
+++ b/strands_bringup/launch/strands_navigation.launch
@@ -15,7 +15,7 @@
   <arg name="z_obstacle_threshold" default="0.15"/>
   <arg name="with_head_xtion" default="false"/>
   <arg name="with_human_aware" default="true"/>
-
+  <arg name="with_social_layer" default="false"/>
   <arg name="with_site_movebase_params" default="false"/>
   <arg name="site_movebase_params" default=""/>
 
@@ -47,6 +47,7 @@
     <arg name="with_no_go_map" value="$(arg with_no_go_map)"/>
     <arg name="with_mux" value="$(arg with_mux)"/>
     <arg name="no_go_map" value="$(arg no_go_map)"/>
+    <arg name="with_social_layer" value="$(arg with_social_layer)"/>
     
     <arg name="z_stair_threshold" value="$(arg z_stair_threshold)"/>
     <arg name="z_obstacle_threshold" value="$(arg z_obstacle_threshold)"/>


### PR DESCRIPTION
Added the parameter "with_social_layer" that by default is set to false. The new parameters will allow the use of the [Proxemic and Passing layers](https://github.com/DLu/navigation_layers/tree/indigo/social_navigation_layers) to be added to the global costmap.
