### PR TITLE
Expose the PTU device as argument so it can be set on commandline.

### DIFF
--- a/strands_bringup/launch/strands_robot.launch
+++ b/strands_bringup/launch/strands_robot.launch
@@ -5,6 +5,7 @@
 	<arg name="with_mux" default="false" />
 	<arg name="js" default="$(optenv JOYSTICK_DEVICE /dev/js1)" />
 	<arg name="laser" default="/dev/ttyUSB0" />
+	<arg name="ptu" default="/dev/ttyS0" />
 	<arg name="scitos_config" default="$(find scitos_mira)/resources/SCITOSDriver.xml"/>
 	<arg name="with_magnetic_barrier" default="true"/>
 
@@ -32,6 +33,7 @@
 	<include file="$(find flir_pantilt_d46)/launch/ptu46.launch">
 	    <arg name="machine"  value="$(arg machine)"/>
 	    <arg name="user"  value="$(arg user)"/>
+	    <arg name="port"  value="$(arg ptu)"/>
 	</include>
 
 


### PR DESCRIPTION
This needs strands-project/scitos_drivers#113 to work.
