### PR TITLE
add default to no_go_map

### DIFF
--- a/strands_bringup/launch/strands_navigation.launch
+++ b/strands_bringup/launch/strands_navigation.launch
@@ -7,7 +7,7 @@
 
   <arg name="map"/>
   <arg name="with_no_go_map" default="false"/>
-  <arg name="no_go_map"/>
+  <arg name="no_go_map" default=""/>
   <arg name="with_mux" default="false" />
   <arg name="topological_map"/>
   <arg name="mon_nav_config_file" default="$(find strands_recovery_behaviours)/config/monitored_nav_config.yaml"/>


### PR DESCRIPTION
so that we can launch strands_navigation.launch without having to write the path to the metric map twice.

This is consistent with defaulting with_no_go_map to false. I added the same default to the strands_movebase in https://github.com/strands-project/strands_movebase/pull/69
